### PR TITLE
Small boosts to Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Zeta code needs Unix line endings currently
+# Use Unix line endings
 * text eol=lf
 
 # Custom for Visual Studio

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Zeta code needs Unix line endings currently
+* text eol=lf
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ cplush
 cjs
 cscheme
 *.dSYM
-
-# Hey, it works on Windows too!
 *.exe
 *.dll
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,14 +13,19 @@ cjs
 cscheme
 *.dSYM
 
+# Hey, it works on Windows too!
+*.exe
+*.dll
+
 # Generated files
 benchmarks/plush_parser.zim
 packages/lang/plush/0/package
 packages/std/math/0/package
+parseOut.txt
 
-# Retarded MacOS metadata
+# Moronic MacOS metadata
 .DS_Store
 
-# Retarded IDE metadata
+# Infantile IDE metadata
 .idea
 .vscode

--- a/plush/math.pls
+++ b/plush/math.pls
@@ -70,7 +70,7 @@ exports.sqrt = function (x)
 
     assert(
         false,
-        "unhandled type in sin function"
+        "unhandled type in sqrt function"
     );
 };
 

--- a/plush/parser.cpp
+++ b/plush/parser.cpp
@@ -58,7 +58,7 @@ const OpInfo OP_ASSIGN = { "=", "", 2, 1, 'r', false };
 /// Read an entire file at once
 std::string readFile(std::string fileName)
 {
-    FILE* file = fopen(fileName.c_str(), "r");
+    FILE* file = fopen(fileName.c_str(), "rb");
 
     if (!file)
     {

--- a/scheme/parser.cpp
+++ b/scheme/parser.cpp
@@ -13,7 +13,7 @@
 /// Read an entire file at once
 std::string readFile(std::string fileName)
 {
-    FILE* file = fopen(fileName.c_str(), "r");
+    FILE* file = fopen(fileName.c_str(), "rb");
 
     if (!file)
     {

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -13,7 +13,7 @@
 /// Read an entire file at once
 std::string readFile(std::string fileName)
 {
-    FILE* file = fopen(fileName.c_str(), "r");
+    FILE* file = fopen(fileName.c_str(), "rb");
 
     if (!file)
     {


### PR DESCRIPTION
Running `make test` still fails in this version of the code, but it gets further on Windows than it would before. Having a .gitattributes file is good in general, and I think I didn't break anything in .gitignore (my only question would be if it should ignore `parseOut.txt`). Files are opened in binary mode, which helps Cygwin know not to produce CRLF files. A copy/paste typo in math.pls has been corrected (sqrt used the error message for sin if it was incorrect).