### PR TITLE
Small changes to get ZetaVM passing all its tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Zeta code needs Unix line endings currently
+# Use Unix line endings
 * text eol=lf
 
 # Custom for Visual Studio

--- a/makefile.in
+++ b/makefile.in
@@ -4,10 +4,6 @@ LDFLAGS=@LDFLAGS@
 # TODO: change this when doing make install? Move to configure?
 # Directory in which packages are found
 PKGS_DIR=\"$(CURDIR)/packages/\"
-# The previous line was:
-# PKGS_DIR=\"$(shell pwd)/packages/\"
-# There may need to be some fine-tuning to account for OS specifics. CURDIR is
-# part of GNU Make, so it may be successful when shell commands aren't.
 
 # Add a preprocessor definition for the packages directory
 CXXFLAGS:=${CXXFLAGS} -DPKGS_DIR="${PKGS_DIR}"

--- a/makefile.in
+++ b/makefile.in
@@ -3,7 +3,11 @@ LDFLAGS=@LDFLAGS@
 
 # TODO: change this when doing make install? Move to configure?
 # Directory in which packages are found
-PKGS_DIR=\"$(shell pwd)/packages/\"
+PKGS_DIR=\"$(CURDIR)/packages/\"
+# The previous line was:
+# PKGS_DIR=\"$(shell pwd)/packages/\"
+# There may need to be some fine-tuning to account for OS specifics. CURDIR is
+# part of GNU Make, so it may be successful when shell commands aren't.
 
 # Add a preprocessor definition for the packages directory
 CXXFLAGS:=${CXXFLAGS} -DPKGS_DIR="${PKGS_DIR}"

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1479,9 +1479,8 @@ Value execCode()
                 }
 
                 auto ch = str[idx];
-
                 // Cache single-character strings
-                if (charStrings[ch] == Value::FALSE)
+                if (charStrings[ch] == Value::UNDEF)
                 {
                     char buf[2] = { (char)str[idx], '\0' };
                     charStrings[ch] = String(buf);

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -70,7 +70,7 @@ public:
     static const Value TRUE;
     static const Value FALSE;
 
-    Value() : Value(FALSE.word, FALSE.tag) {}
+    Value() : Value(UNDEF.word, UNDEF.tag) {}
     Value(refptr p, Tag t) : Value(Word(p), t) {}
     Value(Word w, Tag t);
     ~Value() {}


### PR DESCRIPTION
The first change is in the Makefile (makefile.in, to be precise) to prefer GNU Make's own variables to ones that are dependent on what the OS provides. Using `$(shell pwd)` won't produce a valid path on any Windows installation unless using Cygwin and it is configured to prefer Cygwin's `pwd` program over the one included in the OS, which Cygwin itself discourages doing. Using `$(CURDIR)` should work everywhere Make does (maybe not with BSD Make or the incredibly-non-standard make included with Solaris, but otherwise GNU Make is very standard fare). The other change is to check whether a Value is uninitialized by comparing it to `Value::UNDEF` instead of `Value::FALSE`; this shouldn't make a difference in theory but it seems to make a sizable difference in practice when doing String indexing and a single char needs to be retrieved from the ANSI chars-as-Strings cache. I haven't tested this on Linux or MacOS, but it passes all the tests on Windows.