### PR TITLE
Setting elements in arrays works now.

### DIFF
--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -1219,9 +1219,10 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
         return;
     }
 
-    // Assignment to a property
+    // Assignment to a property or array element
     if (auto binOp = dynamic_cast<BinOpExpr*>(lhsExpr))
     {
+		// object properties
         if (binOp->op == &OP_MEMBER)
         {
             // Get the field name
@@ -1237,6 +1238,23 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
             ctx.addStr("op:'push', val:'" + identExpr->name + "'");
             ctx.addStr("op:'dup', idx:2");
             ctx.addOp("set_field");
+
+            return;
+        }
+		// array elements
+		else if (binOp->op == &OP_INDEX)
+        {
+			// Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
+            // Evaluate the array
+            genExpr(ctx, binOp->lhsExpr);
+
+            // Evaluate the rhs value
+            genExpr(ctx, binOp->rhsExpr);
+
+            ctx.addStr("op:'dup', idx:2");
+            ctx.addOp("set_elem");
 
             return;
         }

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -1244,14 +1244,16 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
         // Array elements
         else if (binOp->op == &OP_INDEX)
         {
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
             // Evaluate the array
             genExpr(ctx, binOp->lhsExpr);
 
             // Evaluate the index
             genExpr(ctx, binOp->rhsExpr);
 
-            // Evaluate the rhs value
-            genExpr(ctx, rhsExpr);
+            ctx.addStr("op:'dup', idx:2");
 
             //ctx.addOp("set_elem");
             runtimeCall(ctx, "setElem", 3);

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -1244,16 +1244,16 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
         // Array elements
         else if (binOp->op == &OP_INDEX)
         {
-            // Evaluate the rhs value
-            genExpr(ctx, rhsExpr);
-
             // Evaluate the array
             genExpr(ctx, binOp->lhsExpr);
 
             // Evaluate the index
             genExpr(ctx, binOp->rhsExpr);
 
-            ctx.addStr("op:'dup', idx:2");
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
+            //ctx.addStr("op:'dup', idx:2");
 
             //ctx.addOp("set_elem");
             runtimeCall(ctx, "setElem", 3);

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -1253,7 +1253,6 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
             // Evaluate the rhs value
             genExpr(ctx, rhsExpr);
 
-            //ctx.addStr("op:'dup', idx:2");
             //ctx.addOp("set_elem");
             runtimeCall(ctx, "setElem", 3);
             return;

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -1222,7 +1222,7 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
     // Assignment to a property or array element
     if (auto binOp = dynamic_cast<BinOpExpr*>(lhsExpr))
     {
-		// object properties
+        // object properties
         if (binOp->op == &OP_MEMBER)
         {
             // Get the field name
@@ -1241,21 +1241,21 @@ void genAssign(CodeGenCtx& ctx, ASTExpr* lhsExpr, ASTExpr* rhsExpr)
 
             return;
         }
-		// array elements
-		else if (binOp->op == &OP_INDEX)
+        // array elements
+        else if (binOp->op == &OP_INDEX)
         {
-			// Evaluate the rhs value
-            genExpr(ctx, rhsExpr);
-
             // Evaluate the array
             genExpr(ctx, binOp->lhsExpr);
 
-            // Evaluate the rhs value
+            // Evaluate the index
             genExpr(ctx, binOp->rhsExpr);
 
-            ctx.addStr("op:'dup', idx:2");
-            ctx.addOp("set_elem");
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
 
+            //ctx.addStr("op:'dup', idx:2");
+            //ctx.addOp("set_elem");
+            runtimeCall(ctx, "setElem", 3);
             return;
         }
 

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -2444,6 +2444,23 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
 
             return;
         }
+		else if (lhsExpr.op == OP_INDEX)
+        {
+
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
+            // Evaluate the array
+            genExpr(ctx, lhsExpr.lhsExpr);
+
+            // Evaluate the array
+            genExpr(ctx, lhsExpr.rhsExpr);
+
+            ctx:addInstr({ op:'dup', idx:2 });
+            ctx:addOp("set_elem");
+
+            return;
+        }
 
         assert (false);
     }

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -2446,14 +2446,16 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
         }
         else if (lhsExpr.op == OP_INDEX)
         {
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
             // Evaluate the array
             genExpr(ctx, lhsExpr.lhsExpr);
 
             // Evaluate the index
             genExpr(ctx, lhsExpr.rhsExpr);
 
-            // Evaluate the rhs value
-            genExpr(ctx, rhsExpr);
+            ctx:addInstr({ op:'dup', idx:2 });
 
             //ctx:addOp("set_elem");
             runtimeCall(ctx, rt_setElem);

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -2446,8 +2446,6 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
         }
         else if (lhsExpr.op == OP_INDEX)
         {
-            // Evaluate the rhs value
-            genExpr(ctx, rhsExpr);
 
             // Evaluate the array
             genExpr(ctx, lhsExpr.lhsExpr);
@@ -2455,7 +2453,10 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
             // Evaluate the index
             genExpr(ctx, lhsExpr.rhsExpr);
 
-            ctx:addInstr({ op:'dup', idx:2 });
+            // Evaluate the rhs value
+            genExpr(ctx, rhsExpr);
+
+            //ctx:addInstr({ op:'dup', idx:2 });
 
             //ctx:addOp("set_elem");
             runtimeCall(ctx, rt_setElem);

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -1534,7 +1534,7 @@ CodeGenCtx.merge = function (ctx, block)
     ctx.curBlock = block;
 };
 
-/// Add an instructionN
+/// Add an instruction
 CodeGenCtx.addInstr = function (ctx, instr)
 {
     assert (ctx.curBlock != false);
@@ -2444,20 +2444,20 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
 
             return;
         }
-		else if (lhsExpr.op == OP_INDEX)
+        else if (lhsExpr.op == OP_INDEX)
         {
+            // Evaluate the array
+            genExpr(ctx, lhsExpr.lhsExpr);
+
+            // Evaluate the index
+            genExpr(ctx, lhsExpr.rhsExpr);
 
             // Evaluate the rhs value
             genExpr(ctx, rhsExpr);
 
-            // Evaluate the array
-            genExpr(ctx, lhsExpr.lhsExpr);
-
-            // Evaluate the array
-            genExpr(ctx, lhsExpr.rhsExpr);
-
-            ctx:addInstr({ op:'dup', idx:2 });
-            ctx:addOp("set_elem");
+            //ctx:addInstr({ op:'dup', idx:2 });
+            //ctx:addOp("set_elem");
+            runtimeCall(ctx, rt_setElem);
 
             return;
         }

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -2455,7 +2455,6 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
             // Evaluate the rhs value
             genExpr(ctx, rhsExpr);
 
-            //ctx:addInstr({ op:'dup', idx:2 });
             //ctx:addOp("set_elem");
             runtimeCall(ctx, rt_setElem);
 

--- a/plush/parser.pls
+++ b/plush/parser.pls
@@ -2446,7 +2446,6 @@ var genAssign = function (ctx, lhsExpr, rhsExpr)
         }
         else if (lhsExpr.op == OP_INDEX)
         {
-
             // Evaluate the array
             genExpr(ctx, lhsExpr.lhsExpr);
 

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -488,7 +488,8 @@ var rt_ge = function (x, y)
         {
             return $ge_f32(x, y);
         }
-        if (typeof y == "int32") {
+        if (typeof y == "int32")
+        {
             return $ge_f32(x, $i32_to_f32(y));
         }
     }
@@ -609,6 +610,7 @@ var rt_getElem = function (base, idx)
             typeof idx == "int32",
             "unhandled index type in getElem with array base; should be int32"
         );
+        
         // TODO: check bounds
         return $get_elem(base, idx);
     }
@@ -619,6 +621,7 @@ var rt_getElem = function (base, idx)
             typeof idx == "int32",
             "unhandled index type in getElem with string base; should be int32"
         );
+        
         // TODO: check bounds
         //if (index < $str_len(base))
         return $get_char(base, idx);
@@ -630,6 +633,7 @@ var rt_getElem = function (base, idx)
             typeof idx == "string",
             "unhandled index type in getElem with object base; should be string"
         );
+        
         return $get_field(base, idx);
     }
 
@@ -648,6 +652,7 @@ var rt_setElem = function (base, idx, val)
             typeof idx == "int32",
             "unhandled index type in setElem with array base; should be int32"
         );
+        
         // TODO: check bounds
         $set_elem(base, idx, val);
         return val;
@@ -659,6 +664,7 @@ var rt_setElem = function (base, idx, val)
             typeof idx == "string",
             "unhandled index type in setElem with object base; should be string"
         );
+        
         return $set_field(base, idx, val);
     }
     

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -649,7 +649,8 @@ var rt_setElem = function (base, idx, val)
             "unhandled index type in setElem with array base; should be int32"
         );
         // TODO: check bounds
-        return $set_elem(base, idx, val);
+        $set_elem(base, idx, val);
+        return val;
     }
 
     if (typeof base == "object")

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -275,8 +275,8 @@ var rt_bit_not = function (x)
     if (typeof x == "int32")
     {
         return $not_i32(x);
-	}
-	assert (
+    }
+    assert (
         false,
         "unhandled type in bitwise not"
     );
@@ -605,12 +605,20 @@ var rt_getElem = function (base, idx)
 {
     if (typeof base == "array")
     {
+        assert (
+            typeof idx == "int32",
+            "unhandled index type in getElem with array base; should be int32"
+        );
         // TODO: check bounds
         return $get_elem(base, idx);
     }
 
     if (typeof base == "string")
     {
+        assert (
+            typeof idx == "int32",
+            "unhandled index type in getElem with string base; should be int32"
+        );
         // TODO: check bounds
         //if (index < $str_len(base))
         return $get_char(base, idx);
@@ -618,12 +626,56 @@ var rt_getElem = function (base, idx)
 
     if (typeof base == "object")
     {
+        assert (
+            typeof idx == "string",
+            "unhandled index type in getElem with object base; should be string"
+        );
         return $get_field(base, idx);
     }
 
     assert (
         false,
-        "unhandled type in getElem"
+        "unhandled base type in getElem; should be array, string, or object"
+    );
+};
+
+/// Assign-to-index operator implementation (ie: base[idx] = val)
+var rt_setElem = function (base, idx, val)
+{
+    if (typeof base == "array")
+    {
+        if(typeof idx == "int32")
+        {
+            // TODO: check bounds
+            return $set_elem(base, idx, val);
+        }
+        else
+        {
+            assert (
+                false,
+                "unhandled index type in setElem with array base; should be int32"
+            );
+        }
+    }
+
+    if (typeof base == "object")
+    {
+        if(typeof idx == "string")
+        {
+            return $set_field(base, idx, val);
+        }
+        else
+        {
+            assert (
+                false,
+                "unhandled index type in setElem with object base; should be string"
+            );
+        }
+    }
+    
+    assert (
+        false,
+        "unhandled base type in setElem; should be array or object"
     );
 };
 

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -649,8 +649,7 @@ var rt_setElem = function (base, idx, val)
             "unhandled index type in setElem with array base; should be int32"
         );
         // TODO: check bounds
-        $set_elem(base, idx, val);
-        return base;
+        return $set_elem(base, idx, val);
     }
 
     if (typeof base == "object")

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -644,33 +644,22 @@ var rt_setElem = function (base, idx, val)
 {
     if (typeof base == "array")
     {
-        if(typeof idx == "int32")
-        {
-            // TODO: check bounds
-            return $set_elem(base, idx, val);
-        }
-        else
-        {
-            assert (
-                false,
-                "unhandled index type in setElem with array base; should be int32"
-            );
-        }
+        assert (
+            typeof idx == "int32",
+            "unhandled index type in setElem with array base; should be int32"
+        );
+        // TODO: check bounds
+        $set_elem(base, idx, val);
+        return base;
     }
 
     if (typeof base == "object")
     {
-        if(typeof idx == "string")
-        {
-            return $set_field(base, idx, val);
-        }
-        else
-        {
-            assert (
-                false,
-                "unhandled index type in setElem with object base; should be string"
-            );
-        }
+        assert (
+            typeof idx == "string",
+            "unhandled index type in setElem with object base; should be string"
+        );
+        return $set_field(base, idx, val);
     }
     
     assert (

--- a/tests/plush/simple_exprs.pls
+++ b/tests/plush/simple_exprs.pls
@@ -99,5 +99,5 @@ arr[1] = 100;
 assert (arr[1] == 100);
 assert (arr[1] == arr[1]);
 assert (arr[1] == arr[0] * 2);
-arr[0] *= 4;
+assert((arr[0] *= 4) == 200);
 assert (arr[0] == arr[1] * 2);

--- a/tests/plush/simple_exprs.pls
+++ b/tests/plush/simple_exprs.pls
@@ -99,5 +99,5 @@ arr[1] = 100;
 assert (arr[1] == 100);
 assert (arr[1] == arr[1]);
 assert (arr[1] == arr[0] * 2);
-//assert((arr[0] *= 4) == 200);
-//assert (arr[0] == arr[1] * 2);
+assert((arr[0] *= 4) == 200);
+assert (arr[0] == arr[1] * 2);

--- a/tests/plush/simple_exprs.pls
+++ b/tests/plush/simple_exprs.pls
@@ -49,8 +49,11 @@ var obj = { x:1, y:2, z:3, w:1+2 };
 assert (obj.x == 1);
 assert (obj.y == 2);
 assert (obj.z == 3);
+assert (obj.w == 3);
 assert ('z' in obj);
 assert (!('k' in obj));
+obj.w = obj.x + obj.z;
+assert (obj.w == 4);
 
 // Type tests
 assert (typeof 1 == "int32", "int type");
@@ -90,3 +93,11 @@ assert ("c" >= "b");
 var arr = [5,7,2];
 assert (arr[1] == 7);
 assert (arr.length == 3);
+arr[0] = 50;
+assert (arr[0] == 50);
+arr[1] = 100;
+assert (arr[1] == 100);
+assert (arr[1] == arr[1]);
+assert (arr[1] == arr[0] * 2);
+arr[0] *= 4;
+assert (arr[0] == arr[1] * 2);

--- a/tests/plush/simple_exprs.pls
+++ b/tests/plush/simple_exprs.pls
@@ -99,5 +99,5 @@ arr[1] = 100;
 assert (arr[1] == 100);
 assert (arr[1] == arr[1]);
 assert (arr[1] == arr[0] * 2);
-assert((arr[0] *= 4) == 200);
+assert((arr[0] *= 4)[0] == 200);
 assert (arr[0] == arr[1] * 2);

--- a/tests/plush/simple_exprs.pls
+++ b/tests/plush/simple_exprs.pls
@@ -99,5 +99,5 @@ arr[1] = 100;
 assert (arr[1] == 100);
 assert (arr[1] == arr[1]);
 assert (arr[1] == arr[0] * 2);
-assert((arr[0] *= 4)[0] == 200);
-assert (arr[0] == arr[1] * 2);
+//assert((arr[0] *= 4) == 200);
+//assert (arr[0] == arr[1] * 2);

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1793,8 +1793,6 @@ Value execCode()
                 }
 
                 arr.setElem(idx, val);
-                
-                pushVal(val);
             }
             break;
 

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1793,6 +1793,8 @@ Value execCode()
                 }
 
                 arr.setElem(idx, val);
+                
+                pushVal(val);
             }
             break;
 


### PR DESCRIPTION
The code is largely similar to how properties on objects are set, but
the subtle differences were a bit difficult at first. This is tested in
simple_exprs.pls, including setting an element of an array with `=`,
setting another element and comparing the two changed ones, and
assigning with `*=`. To ensure I didn't break anything in property
setting, I also added a test for setting an object property, combined
with adding two properties.

I would appreciate someone taking a second look at the
`"op:'dup', idx:2"` and similar code, since I pretty much cargo-cult-ed
that from the object property code, and I don't know if it's necessary
or if it may cause some kind of issue.

As an aside, building and testing ZetaVM seems faster, and I am guessing
the recent commits with performance in mind are to credit. It's a lot
more pleasant to work with now that compiles are faster!