### PR TITLE
String Interning implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cscheme
 benchmarks/plush_parser.zim
 packages/lang/plush/0/package
 packages/std/math/0/package
+packages/lang/p/*
 
 # Retarded MacOS metadata
 .DS_Store

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -651,19 +651,6 @@ size_t StringHasher::operator()(const std::string str) const
     return (size_t)hashFunction(ptr, len, 1337);
 }
 
-// bool StringDeepComparison::operator()(const Value str1, const Value str2) const 
-// {
-//     auto ptr1 = (refptr)str1;
-//     assert (ptr1 != nullptr);
-//     auto len1 = *(uint32_t*)(ptr1 + String::OF_LEN);
-//     auto strdata1 = (char*)(ptr1 + String::OF_DATA);
-//     auto ptr2 = (refptr)str2;
-//     assert (ptr2 != nullptr);
-//     auto len2 = *(uint32_t*)(ptr2 + String::OF_LEN); 
-//     auto strdata2 = (char*)(ptr2 + String::OF_DATA);    
-//     return len1 == len2 && strncmp(strdata1, strdata2, len1) == 0;
-// }
-
 Value StringPool::getString(std::string str) 
 {
     auto iter = pool.find(str);

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -602,7 +602,7 @@ std::string ImgRef::getName() const
 }
 
 //Murmurhash, learn more at: https://en.wikipedia.org/wiki/MurmurHash
-int64_t hashFunction(const void* key, size_t len, uint64_t seed)
+int64_t murmurHash2(const void* key, size_t len, uint64_t seed)
 {
     const uint64_t m = 0xc6a4a7935bd1e995;
     const int r = 47;
@@ -645,24 +645,18 @@ int64_t hashFunction(const void* key, size_t len, uint64_t seed)
     return h;
 }
 
-size_t StringHasher::operator()(const std::string str) const 
-{
-    auto len = str.length();
-    auto ptr = str.c_str();
-    return (size_t)hashFunction(ptr, len, 1337);
-}
 
 Value StringPool::getString(std::string str) 
 {
     auto iter = pool.find(str);
     if (iter == pool.end())
     {
-        return addNewString(str);
+        return newString(str);
     }
     return iter->second;
 }
 
-Value StringPool::addNewString(std::string str)
+Value StringPool::newString(std::string str)
 {
     auto len = str.length();
     // Compute the string object size

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -601,6 +601,7 @@ std::string ImgRef::getName() const
     return (std::string)strVal;
 }
 
+//Murmurhash, learn more at: https://en.wikipedia.org/wiki/MurmurHash
 int64_t hashFunction(const void* key, size_t len, uint64_t seed)
 {
     const uint64_t m = 0xc6a4a7935bd1e995;

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <cstring>
 #include <unordered_map>
-#include  <mutex>
 
 /// Type tag, 8 bits
 typedef uint8_t Tag;

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 #include <cstring>
+#include <unordered_map>
+#include  <mutex>
 
 /// Type tag, 8 bits
 typedef uint8_t Tag;
@@ -228,7 +230,6 @@ public:
     {
         return OF_DATA + (len + 1) * sizeof(char);
     }
-
     String(std::string str);
     String(Value value);
 
@@ -247,11 +248,7 @@ public:
 
     // FIXME: temporary until string interning is implemented
     bool operator == (String that) { 
-        auto len1 = length();     
-        auto len2 = that.length();     
-        const char* dataptr1 = getDataPtr(); 
-        const char* dataptr2 = that.getDataPtr(); 
-        return len1 == len2 && strncmp(dataptr1, dataptr2, len1) == 0;
+        return val == that.val;
     }
 
     /// Get the ith character code
@@ -405,6 +402,28 @@ public:
     ImgRef(Value val);
 
     std::string getName() const;
+};
+
+class StringHasher
+{
+public:
+    size_t operator()(const std::string str) const;
+};
+
+// class StringDeepComparison
+// {
+// public:
+//     bool operator()(const Value str1, const Value str2) const;
+// };
+
+class StringPool
+{
+private:
+    std::unordered_map<std::string, Value, StringHasher> pool;
+    Value addNewString(std::string str);
+public: 
+    StringPool();
+    Value getString(std::string str);
 };
 
 /// Global virtual machine instance

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -410,12 +410,6 @@ public:
     size_t operator()(const std::string str) const;
 };
 
-// class StringDeepComparison
-// {
-// public:
-//     bool operator()(const Value str1, const Value str2) const;
-// };
-
 class StringPool
 {
 private:

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -403,17 +403,23 @@ public:
     std::string getName() const;
 };
 
-class StringHasher
-{
-public:
-    size_t operator()(const std::string str) const;
-};
+int64_t murmurHash2(const void* key, size_t len, uint64_t seed);
 
 class StringPool
 {
 private:
+    class StringHasher
+    {
+    public:
+        size_t operator()(const std::string str) const
+        {
+            auto len = str.length();
+            auto ptr = str.c_str();
+            return (size_t)murmurHash2(ptr, len, 1337);
+        }
+    };
     std::unordered_map<std::string, Value, StringHasher> pool;
-    Value addNewString(std::string str);
+    Value newString(std::string str);
 public: 
     StringPool();
     Value getString(std::string str);


### PR DESCRIPTION
I implemented string interning in zeta. In order to accomplish this I used an unordered_map, but the code is relatively modular, so changing the internal implementation of the StringPool shouldn't be too difficult. (The StringPool is the class that takes care of managing strings).

I've done the benchmarks on my machine and they seem quite good!

Before:
```
benchmarks/img_fill.pls               337 ms
benchmarks/incr_field_1m.pls          641 ms
benchmarks/fcalls_10m.zim             885 ms
benchmarks/fib29.pls                  699 ms
benchmarks/loop_cnt_100m.zim         4110 ms
benchmarks/plush_parser.zim           320 ms
benchmarks/saw_wave.pls               770 ms
benchmarks/sine_wave.pls              873 ms
--------------------------------------------
geometric mean                        766 ms
``` 

After: 
```
benchmarks/img_fill.pls               282 ms
benchmarks/incr_field_1m.pls          648 ms
benchmarks/fcalls_10m.zim             929 ms
benchmarks/fib29.pls                  658 ms
benchmarks/loop_cnt_100m.zim         4299 ms
benchmarks/plush_parser.zim           203 ms
benchmarks/saw_wave.pls               614 ms
benchmarks/sine_wave.pls              781 ms
--------------------------------------------
geometric mean                        682 ms
```

The plush_parser got a nice boost!