### PR TITLE
Better CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 
 dist: trusty 
 
+os:
+    - osx
+
 services:
     - docker 
 
@@ -9,6 +12,7 @@ language: bash
 
 matrix:
   include:
+    - os: osx
     # works on Precise and Trusty
     - os: linux
       env:
@@ -20,11 +24,12 @@ matrix:
          - CXX="clang++"
 
 install:
-    - docker build -t zetavm/testing .
-    - docker run -td --name zetavm -e CXX=$CXX zetavm/testing
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t zetavm/testing . ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run -td --name zetavm -e CXX=$CXX zetavm/testing ; fi
 
 script:
-    - docker exec zetavm ./configure
-    - docker exec zetavm make
-    - docker exec zetavm make test
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm ./configure ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make test ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure && make && make test ; fi 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,3 @@
+test_script: 
+    - C:\cygwin64\bin\sh -lc "cd /cygdrive/c/projects/zetavm  && ./configure && make && make test"
+build: off


### PR DESCRIPTION
I've add the support for macOS on travis, so now we are testing on:
- Linux, gcc
- Linux, clang
- MacOS, clang

I've also added a file called appveyor.yml that allows us to test on windows (using cygwin) on https://www.appveyor.com/ (I've already tested this on my fork) 

I've noticed that if I use on my machine autoconf to generate the configure script, it doesn't work and it fails with: 
```
./configure: line 2282: syntax error near unexpected token `SDL,'
./configure: line 2282: `    PKG_CHECK_MODULES(SDL, sdl2 >= 2.0.0, CXXFLAGS="${CXXFLAGS} -DHAVE_SDL2")'
```
Apparently it's a known issue. We may need to investigate this further.