### PR TITLE
Fixes -Wall warnings and enables -Wall

### DIFF
--- a/configure
+++ b/configure
@@ -2262,7 +2262,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-CXXFLAGS="-std=c++11 -O3 -ftrapv"
+CXXFLAGS="-std=c++11 -O3 -ftrapv -Wall"
 
 # Option to disable assertions and debug information
 # Check whether --enable-ndebug was given.

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT
 # Configure the C++ compiler
 AC_PROG_CXX
 
-CXXFLAGS="-std=c++11 -O3 -ftrapv"
+CXXFLAGS="-std=c++11 -O3 -ftrapv -Wall"
 
 # Option to disable assertions and debug information
 AC_ARG_ENABLE(

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -145,9 +145,6 @@ public:
     /// Current function being generated
     Function* fun;
     
-    /// Unit function flag
-    bool unitFun;
-
     /// Current block into which to insert
     Block* curBlock;
 
@@ -159,7 +156,9 @@ public:
 
     /// Try catch block
     Block* catchBlock;
-
+    
+    /// Unit function flag
+    bool unitFun;
 
     CodeGenCtx(
         std::string& out,
@@ -172,11 +171,11 @@ public:
     )
     : out(out),
       fun(fun),
-      unitFun(unitFun),
       curBlock(curBlock),
       contBlock(contBlock),
       breakBlock(breakBlock),
-      catchBlock(catchBlock)
+      catchBlock(catchBlock),
+      unitFun(unitFun)
     {
     }
 

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -144,6 +144,9 @@ public:
 
     /// Current function being generated
     Function* fun;
+    
+    /// Unit function flag
+    bool unitFun;
 
     /// Current block into which to insert
     Block* curBlock;
@@ -157,8 +160,6 @@ public:
     /// Try catch block
     Block* catchBlock;
 
-    /// Unit function flag
-    bool unitFun;
 
     CodeGenCtx(
         std::string& out,
@@ -284,7 +285,7 @@ void registerDecls(Function* fun, ASTStmt* stmt, bool unitFun)
         return;
     }
 
-    if (auto exprStmt = dynamic_cast<ExprStmt*>(stmt))
+    if (dynamic_cast<ExprStmt*>(stmt) != nullptr)
     {
         return;
     }
@@ -303,12 +304,12 @@ void registerDecls(Function* fun, ASTStmt* stmt, bool unitFun)
         return;
     }
 
-    if (auto contStmt = dynamic_cast<ContStmt*>(stmt))
+    if (dynamic_cast<ContStmt*>(stmt) != nullptr)
     {
         return;
     }
 
-    if (auto breakStmt = dynamic_cast<BreakStmt*>(stmt))
+    if (dynamic_cast<BreakStmt*>(stmt) != nullptr)
     {
         return;
     }
@@ -325,17 +326,17 @@ void registerDecls(Function* fun, ASTStmt* stmt, bool unitFun)
         return;
     }
 
-    if (auto returnStmt = dynamic_cast<ReturnStmt*>(stmt))
+    if (dynamic_cast<ReturnStmt*>(stmt) != nullptr)
     {
         return;
     }
 
-    if (auto throwStmt = dynamic_cast<ThrowStmt*>(stmt))
+    if (dynamic_cast<ThrowStmt*>(stmt) != nullptr)
     {
         return;
     }
 
-    if (auto irStmt = dynamic_cast<IRStmt*>(stmt))
+    if (dynamic_cast<IRStmt*>(stmt) != nullptr)
     {
         return;
     }
@@ -1032,7 +1033,7 @@ void genStmt(CodeGenCtx& ctx, ASTStmt* stmt)
     }
 
     // Loop break statement
-    if (auto contStmt = dynamic_cast<ContStmt*>(stmt))
+    if (dynamic_cast<ContStmt*>(stmt) != nullptr)
     {
         if (!ctx.curBlock->isFinalized())
             ctx.addBranch("jump", "to", ctx.contBlock);
@@ -1040,7 +1041,7 @@ void genStmt(CodeGenCtx& ctx, ASTStmt* stmt)
     }
 
     // Loop break statement
-    if (auto breakStmt = dynamic_cast<BreakStmt*>(stmt))
+    if (dynamic_cast<BreakStmt*>(stmt) != nullptr)
     {
         if (!ctx.curBlock->isFinalized())
             ctx.addBranch("jump", "to", ctx.breakBlock);

--- a/plush/parser.cpp
+++ b/plush/parser.cpp
@@ -80,7 +80,7 @@ std::string readFile(std::string fileName)
     char* buf = (char*)malloc(len+1);
 
     // Read into the allocated buffer
-    int read = fread(buf, 1, len, file);
+    size_t read = fread(buf, 1, len, file);
 
     if (read != len)
     {
@@ -1288,7 +1288,7 @@ void testParseFail(std::string str)
 
     try
     {
-        auto unit = parseString(str, "parser_fail_test");
+        parseString(str, "parser_fail_test");
     }
 
     catch (ParseError e)

--- a/plush/parser.h
+++ b/plush/parser.h
@@ -578,18 +578,18 @@ public:
         std::vector<std::string> params
     )
     : name(name),
-      body(body),
-      params(params)
+      params(params),
+      body(body)
     {
     }
 
     virtual ~FunExpr() {}
 
     std::string name;
-    
-    ASTStmt* body;
 
     std::vector<std::string> params;
+    
+    ASTStmt* body;
 
 };
 

--- a/plush/parser.h
+++ b/plush/parser.h
@@ -586,10 +586,11 @@ public:
     virtual ~FunExpr() {}
 
     std::string name;
+    
+    ASTStmt* body;
 
     std::vector<std::string> params;
 
-    ASTStmt* body;
 };
 
 FunExpr* parseString(std::string str, std::string srcName);

--- a/vm/core.cpp
+++ b/vm/core.cpp
@@ -116,7 +116,7 @@ Value read_file(Value fileName)
     char* buf = (char*)malloc(len+1);
 
     // Read into the allocated buffer
-    int read = fread(buf, 1, len, file);
+    size_t read = fread(buf, 1, len, file);
 
     if (read != len)
     {

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1035,7 +1035,9 @@ __attribute__((always_inline)) inline void funCall(
         }
 
         static ICache localsIC("num_locals");
-        auto numLocals = localsIC.getInt32(fun);
+        auto nlocals = localsIC.getInt32(fun);
+        assert(nlocals >= 0);
+        auto numLocals = size_t(nlocals);
 
         static ICache paramsIC("params");
         auto params = paramsIC.getArr(fun);
@@ -1614,7 +1616,7 @@ Value execCode()
                     );
                 }
 
-                auto ch = str[idx];
+                uint8_t ch = str[idx];
                 // Cache single-character strings
                 if (charStrings[ch] == Value::UNDEF)
                 {
@@ -2039,7 +2041,9 @@ Value callFun(Object fun, ValueVec args)
     static ICache numLocalsIC("num_locals");
     auto params = paramsIC.getArr(fun);
     auto numParams = size_t(params.length());
-    auto numLocals = numLocalsIC.getInt32(fun);
+    auto nlocals = numLocalsIC.getInt32(fun);
+    assert(nlocals >= 0);
+    auto numLocals = size_t(nlocals);
 
     if (args.size() != numParams)
     {

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -31,7 +31,7 @@ std::string readFile(std::string fileName)
     char* buf = (char*)malloc(len+1);
 
     // Read into the allocated buffer
-    int read = fread(buf, 1, len, file);
+    size_t read = fread(buf, 1, len, file);
 
     if (read != len)
     {

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -528,7 +528,6 @@ bool ObjFieldItr::valid()
 std::string ObjFieldItr::get()
 {
     auto ptr = obj.getObjPtr();
-    auto cap = obj.getCap();
     auto values = (Value*)(ptr + Object::OF_FIELDS);
 
     //std::cout << "cap=" << cap << std::endl;


### PR DESCRIPTION
Compiling with -Wall is imo good practice. This PR fixes all -Wall warnings that gcc and clang report and enables -Wall in the configure script.