### PR TITLE
Make some operators and constructors inlineable

### DIFF
--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -73,29 +73,6 @@ bool Value::isPointer() const
     }
 }
 
-Value::operator bool () const
-{
-    assert (tag == TAG_BOOL);
-    return word.int64? 1:0;
-}
-
-Value::operator int32_t () const
-{
-    assert (tag == TAG_INT32);
-    return word.int32;
-}
-
-Value::operator float () const
-{
-    assert (tag == TAG_FLOAT32);
-    return word.float32;
-}
-
-Value::operator refptr () const
-{
-    assert (isPointer());
-    return word.ptr;
-}
 
 Value::operator std::string () const
 {

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -20,12 +20,6 @@ const Value Value::TWO(Word(int64_t(2)), TAG_INT32);
 // Global virtual machine instance
 VM vm;
 
-Value::Value(Word w, Tag t)
-{
-    word = w;
-    tag = t;
-}
-
 /// Produce a string representation of a value
 std::string Value::toString() const
 {

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -95,10 +95,30 @@ public:
 
     std::string toString() const;
 
-    operator bool () const;
-    operator int32_t () const;
-    operator float () const;
-    operator refptr () const;
+    inline operator bool () const
+    {
+        assert (tag == TAG_BOOL);
+        return word.int64? 1:0;
+    }
+
+    inline operator int32_t () const
+    {
+        assert (tag == TAG_INT32);
+        return word.int32;
+    }
+
+    inline operator float () const
+    {
+        assert (tag == TAG_FLOAT32);
+        return word.float32;
+    }
+
+    inline operator refptr () const
+    {
+        assert (isPointer());
+        return word.ptr;
+    }
+    
     operator std::string () const;
 
     bool operator == (const Value& that) const

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -73,7 +73,7 @@ public:
 
     Value() : Value(UNDEF.word, UNDEF.tag) {}
     Value(refptr p, Tag t) : Value(Word(p), t) {}
-    Value(Word w, Tag t);
+    Value(Word w, Tag t) : word(w), tag(t) {};
     ~Value() {}
 
     // Static constructors. These are needed because of type ambiguity.


### PR DESCRIPTION
This makes some cast operators and a constructor inlineable, since inlining them makes the interpreter a bit faster.

Before:
```
benchmarks/img_fill.pls               214 ms
benchmarks/incr_field_1m.pls          643 ms
benchmarks/fcalls_10m.zim             989 ms
benchmarks/fib29.pls                  693 ms
benchmarks/loop_cnt_100m.zim         5120 ms
benchmarks/plush_parser.zim           171 ms
benchmarks/saw_wave.pls               541 ms
benchmarks/sine_wave.pls              682 ms
benchmarks/func_audio.pls            2469 ms
--------------------------------------------
geometric mean                        750 ms
```

After:
```
benchmarks/img_fill.pls               210 ms
benchmarks/incr_field_1m.pls          604 ms
benchmarks/fcalls_10m.zim             729 ms
benchmarks/fib29.pls                  615 ms
benchmarks/loop_cnt_100m.zim         2953 ms
benchmarks/plush_parser.zim           164 ms
benchmarks/saw_wave.pls               515 ms
benchmarks/sine_wave.pls              634 ms
benchmarks/func_audio.pls            2268 ms
--------------------------------------------
geometric mean                        649 ms
```

This has a huge impact on loop_cnt_100m, the other benchmarks just show minor improvements.