### PR TITLE
[Scheme] Add support for booleans

### DIFF
--- a/scheme/codegen.cpp
+++ b/scheme/codegen.cpp
@@ -379,6 +379,12 @@ static void genValue(CodeGenCtx& ctx, Value* value)
         ctx.addStr("op:'push', val:" + str->toString());
     }
 
+    // Push a boolean
+    else if (auto boolean = dynamic_cast<Boolean*>(value))
+    {
+        ctx.addStr("op:'push', val:" + std::string(boolean->val ? "$true" : "$false"));
+    }
+
     // Recursively generate code on the pair
     else if (auto pair = dynamic_cast<Pair*>(value))
     {

--- a/scheme/parser.h
+++ b/scheme/parser.h
@@ -165,6 +165,22 @@ public:
     std::string val;
 };
 
+class Boolean : public Value
+{
+public:
+
+    Boolean(bool val): val(val) {}
+
+    virtual ~Boolean() {}
+
+    virtual std::string toString() const
+    {
+        return val ? "#t" : "#f";
+    }
+
+    bool val;
+};
+
 class Pair : public Value
 {
 public:

--- a/scheme/runtime.zim
+++ b/scheme/runtime.zim
@@ -16,13 +16,53 @@ write = {
   params: ['v'],
   num_locals: 2,
   entry: {
-    name: 'write_entry',
+    name: 'write_dispatch_0',
     instrs: [
       { op:'get_local', idx:0 },
       { op:'has_tag', tag:'int32' },
-      { op:'if_true', then:@write_int32, else:@write_str },
+      { op:'if_true', then:@write_int32, else:@write_dispatch_1 },
     ]
   }
+};
+
+write_dispatch_1 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'bool' },
+    { op:'if_true', then:@write_bool, else:@write_str },
+  ]
+};
+
+write_bool = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'if_true', then:@write_bool_true, else:@write_bool_false },
+  ]
+};
+
+write_bool_true = {
+  instrs: [
+    { op:'push', val: "#t" },
+    { op:'jump', to: @write_bool_common},
+  ]
+};
+
+write_bool_false = {
+  instrs: [
+    { op:'push', val: "#f" },
+    { op:'jump', to: @write_bool_common},
+  ]
+};
+
+write_bool_common = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'io' },
+    { op:'get_field' },
+    { op:'push', val:'print_str' },
+    { op:'get_field' },
+    { op:'call', ret_to:@write_ret, num_args:1 },
+  ]
 };
 
 write_str = {

--- a/tests/scheme/write.scm
+++ b/tests/scheme/write.scm
@@ -4,3 +4,7 @@
 (newline)
 (write "Good Bye!")
 (newline)
+(write #true)
+(newline)
+(write #false)
+(newline)


### PR DESCRIPTION
This patch adds support for parsing and generating code for
boolean literals.  A small bug related to how delimiters
are handled was fixed as well (it was discovered in the
course of implementing boolean literals).