### PR TITLE
Instruction combination prototype

### DIFF
--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -544,18 +544,21 @@ void compile(BlockVersion* version)
             static ICache valIC("val");
             auto val = valIC.getField(instr);
             std::string nextOp = getOp(instrs, i + 1);
+            
             if (nextOp == "add_i32" && val == Value::ONE)
             {
                 i += 1;
                 writeCode(INC_I32);
                 continue;
             }
+            
             if (nextOp == "sub_i32" && val == Value::ONE)
             {
                 i += 1;
                 writeCode(DEC_I32);
                 continue;
             }
+            
             if (nextOp == "get_field")
             {
                 i += 1;
@@ -564,6 +567,7 @@ void compile(BlockVersion* version)
                 writeCode(size_t(0));
                 continue;
             }
+            
             numTmps += 1;
             writeCode(PUSH);
             writeCode(val);
@@ -2028,6 +2032,7 @@ Value execCode()
                 pushVal(val);
             }
             break;
+
             case GET_FIELD_IMM:
             {
                 auto& fieldName = readCode<String>();


### PR DESCRIPTION
See discussion in #3.

Currently combines: `push 1, add_i32 -> inc_i32`, `push 1, sub_i32 -> dec_i32`, `push field, get_field -> get_field_imm field`, `get_local, has_tag -> local_has_tag`. This speeds up the benchmarks a bit. However the results are not overwhelming since the plush code generator wraps all operations in function calls.

master:
```
benchmarks/loop_cnt_100m.zim         2822 ms
benchmarks/incr_field_1m.pls          497 ms
benchmarks/get_field_1m.pls           516 ms
benchmarks/set_field_1m.pls           294 ms
benchmarks/fcalls_10m.zim             675 ms
benchmarks/fib29.pls                  569 ms
benchmarks/fib36.zim                 3082 ms
benchmarks/plush_parser.zim           133 ms
benchmarks/img_fill.pls               202 ms
benchmarks/saw_wave.pls               461 ms
benchmarks/sine_wave.pls              541 ms
benchmarks/func_audio.pls            1966 ms
benchmarks/rand_floats_1m.pls        3345 ms
benchmarks/zsdf.pls                  7856 ms
--------------------------------------------
geometric mean                        840 ms
```

This PR:
```
benchmarks/loop_cnt_100m.zim         2458 ms
benchmarks/incr_field_1m.pls          493 ms
benchmarks/get_field_1m.pls           465 ms
benchmarks/set_field_1m.pls           286 ms
benchmarks/fcalls_10m.zim             644 ms
benchmarks/fib29.pls                  523 ms
benchmarks/fib36.zim                 3031 ms
benchmarks/plush_parser.zim           125 ms
benchmarks/img_fill.pls               169 ms
benchmarks/saw_wave.pls               413 ms
benchmarks/sine_wave.pls              512 ms
benchmarks/func_audio.pls            1833 ms
benchmarks/rand_floats_1m.pls        3199 ms
benchmarks/zsdf.pls                  7422 ms
--------------------------------------------
geometric mean                        782 ms
```
~7% improvement