### PR TITLE
Add ret_to to handwritten import

### DIFF
--- a/benchmarks/fib36.zim
+++ b/benchmarks/fib36.zim
@@ -63,7 +63,11 @@ main_entry = {
     instrs: [
         # Import the "api/io" package
         { op: "push", val:"core/io/0" },
-        { op: "import" },
+        { op: "import", ret_to: @main_body },
+    ]
+};
+main_body = {
+    instrs: [
         { op: "dup", idx:0 },
 
         { op: "push", val: "print_int32" },


### PR DESCRIPTION
What the title says. The handwritten fib36.zim was not updated to the new import usage.