### PR TITLE
Allow parallel and incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ cscheme
 *.dll
 *.pyc
 
+# Object files
+vm/*.o
+plush/*.o
+
 # Generated files
 benchmarks/plush_parser.zim
 packages/lang/plush/0/package

--- a/makefile.in
+++ b/makefile.in
@@ -14,7 +14,7 @@ test: all
 	./run_tests.sh
 
 clean:
-	rm -rf *.o *.dSYM $(ZETA_BIN) $(CPLUSH_BIN) $(CSCHEME_BIN) config.status config.log
+	rm -rf *.o *.dSYM $(ZETA_BIN) $(CPLUSH_BIN) $(CSCHEME_BIN) config.status config.log plush/*.o zeta/*.o
 
 # Tells make which targets are not files
 .PHONY: all test clean plush-pkg
@@ -33,9 +33,9 @@ vm/interp.cpp   	\
 vm/packages.cpp 	\
 vm/main.cpp     	\
 
-ZETA_OBJECTS= $(ZETA_SRCS:vm/%.cpp=%.o)
+ZETA_OBJECTS= $(ZETA_SRCS:vm/%.cpp=vm/%.o)
 
-%.o: vm/%.cpp vm/*.h
+vm/%.o: vm/%.cpp vm/*.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(ZETA_BIN): $(ZETA_OBJECTS)
@@ -52,9 +52,9 @@ plush/parser.cpp  	\
 plush/codegen.cpp 	\
 plush/main.cpp    	\
 
-CPLUSH_OBJECTS= $(CPLUSH_SRCS:plush/%.cpp=%.o)
+CPLUSH_OBJECTS= $(CPLUSH_SRCS:plush/%.cpp=plush/%.o)
 
-%.o: plush/%.cpp plush/*.h
+plush/%.o: plush/%.cpp plush/*.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(CPLUSH_BIN): $(CPLUSH_OBJECTS)

--- a/makefile.in
+++ b/makefile.in
@@ -52,19 +52,24 @@ plush/parser.cpp  	\
 plush/codegen.cpp 	\
 plush/main.cpp    	\
 
-cplush: plush/*.cpp plush/*.h
-	$(CXX) $(CXXFLAGS) -o $(CPLUSH_BIN) $(CPLUSH_SRCS)
+CPLUSH_OBJECTS= $(CPLUSH_SRCS:plush/%.cpp=%.o)
 
-plush-pkg: cplush plush/parser.pls
+%.o: plush/%.cpp plush/*.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(CPLUSH_BIN): $(CPLUSH_OBJECTS)
+	$(CXX) $(CXXFLAGS) -o $(CPLUSH_BIN) $(CPLUSH_OBJECTS)
+
+plush-pkg: $(CPLUSH_BIN) plush/parser.pls
 	mkdir -p packages/lang/plush/0
 	./$(CPLUSH_BIN) plush/parser.pls > packages/lang/plush/0/package
 	./$(CPLUSH_BIN) tests/plush/parser.pls > packages/lang/plush/0/tests
 
 # Plush parser benchmark
-plush-bench: cplush
+plush-bench: $(CPLUSH_BIN)
 	./$(CPLUSH_BIN)  benchmarks/plush_parser.pls > benchmarks/plush_parser.zim
 
-math-pkg: cplush plush/parser.pls
+math-pkg: $(CPLUSH_BIN) plush/parser.pls
 	mkdir -p packages/std/math/0
 	./$(CPLUSH_BIN) plush/math.pls > packages/std/math/0/package
 
@@ -79,5 +84,5 @@ scheme/parser.cpp   \
 scheme/codegen.cpp  \
 scheme/main.cpp     \
 
-cscheme: scheme/*.cpp scheme/*.h
+$(CSCHEME_BIN): scheme/*.cpp scheme/*.h
 	$(CXX) $(CXXFLAGS) -o $(CSCHEME_BIN) $(CSCHEME_SRCS)

--- a/makefile.in
+++ b/makefile.in
@@ -60,6 +60,7 @@ plush/%.o: plush/%.cpp plush/*.h
 $(CPLUSH_BIN): $(CPLUSH_OBJECTS)
 	$(CXX) $(CXXFLAGS) -o $(CPLUSH_BIN) $(CPLUSH_OBJECTS)
 
+# Plush language package
 plush-pkg: $(CPLUSH_BIN) plush/parser.pls
 	mkdir -p packages/lang/plush/0
 	./$(CPLUSH_BIN) plush/parser.pls > packages/lang/plush/0/package

--- a/makefile.in
+++ b/makefile.in
@@ -33,8 +33,13 @@ vm/interp.cpp   	\
 vm/packages.cpp 	\
 vm/main.cpp     	\
 
-zeta: vm/*.cpp vm/*.h
-	$(CXX) $(CXXFLAGS) -o $(ZETA_BIN) $(ZETA_SRCS) $(LDFLAGS)
+ZETA_OBJECTS= $(ZETA_SRCS:vm/%.cpp=%.o)
+
+%.o: vm/%.cpp vm/*.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(ZETA_BIN): $(ZETA_OBJECTS)
+	$(CXX) $(CXXFLAGS) -o $(ZETA_BIN) $(ZETA_OBJECTS) $(LDFLAGS)
 
 ##############################################################################
 # Plush compiler
@@ -50,16 +55,16 @@ plush/main.cpp    	\
 cplush: plush/*.cpp plush/*.h
 	$(CXX) $(CXXFLAGS) -o $(CPLUSH_BIN) $(CPLUSH_SRCS)
 
-plush-pkg: plush/parser.pls
+plush-pkg: cplush plush/parser.pls
 	mkdir -p packages/lang/plush/0
 	./$(CPLUSH_BIN) plush/parser.pls > packages/lang/plush/0/package
 	./$(CPLUSH_BIN) tests/plush/parser.pls > packages/lang/plush/0/tests
 
 # Plush parser benchmark
-plush-bench:
+plush-bench: cplush
 	./$(CPLUSH_BIN)  benchmarks/plush_parser.pls > benchmarks/plush_parser.zim
 
-math-pkg: plush/parser.pls
+math-pkg: cplush plush/parser.pls
 	mkdir -p packages/std/math/0
 	./$(CPLUSH_BIN) plush/math.pls > packages/std/math/0/package
 


### PR DESCRIPTION
This makes the Makefile slightly more complicated to allow separate compilation to object files of zeta and cplush.

Motivation:
```
master
make clean zeta -j4  18.39s user 0.58s system 100% cpu 18.967 total

master small change in interp.cpp
make zeta -j4  18.40s user 0.56s system 99% cpu 18.959 total

parallel-build
make clean zeta -j4  28.91s user 0.74s system 272% cpu 10.875 total

parallel-build small change in interp.cpp
make zeta -j4  3.20s user 0.09s system 99% cpu 3.293 total
```
Especially the 3s buildtime when making a change to a single source file is imo desirable.
