### PR TITLE
Method calls now have a catch_to field

### DIFF
--- a/plush/plush_pkg.pls
+++ b/plush/plush_pkg.pls
@@ -1767,12 +1767,17 @@ var genExpr = function (ctx, expr)
 
         var contBlock = Block.new();
 
-        ctx:addInstr({
+        var callInstr = {
             op: "call",
-            ret_to:contBlock,
             num_args: args.length+1,
-            src_pos: expr.srcPos
-        });
+            src_pos: expr.srcPos,
+            ret_to: contBlock
+        };
+
+        if (ctx.catchBlock != false)
+            callInstr.throw_to = ctx.catchBlock;
+
+        ctx:addInstr(callInstr);
 
         ctx:merge(contBlock);
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -92,6 +92,7 @@ set -x
 ./zeta tests/plush/regress_exc_var.pls
 ./zeta tests/plush/regress_exc_idx.pls
 ./zeta tests/plush/regress_throw_str.pls | grep -q "foobar"
+./zeta tests/plush/regress_method_exc.pls
 
 # Check that source position is reported on errors
 ./zeta tests/plush/assert.pls | grep -q "3:1"

--- a/tests/plush/regress_method_exc.pls
+++ b/tests/plush/regress_method_exc.pls
@@ -1,0 +1,13 @@
+#language "lang/plush/0"
+
+var string = import("std/string/0");
+var Book = {year: "",};
+Book.yearAsInt = function(self)
+{
+  return string.parseInt(self.year, 10);
+};
+var myBook = Book::{year: "Not an int"};
+try { Book.yearAsInt(myBook); } catch (e) {}
+print("Exception Handled Successfully");
+try { myBook:yearAsInt(); } catch (e) {}
+print("Control does not reach here");


### PR DESCRIPTION
The self-hosted plush implementation was missing catch_to fields
when creating an operation for a method call.
I have mostly copied what we do in normal function calls and have
ported it to method calls.

This bug is reproducible with this code:
```
#language "lang/plush/0"

var string = import("std/string/0");
var Book = {year: "",};
Book.yearAsInt = function(self)
{
  return string.parseInt(self.year, 10);
};
var myBook = Book::{year: "Not an int"};
try { Book.yearAsInt(myBook); } catch (e) {}
print("Exception Handled Successfully");
try { myBook:yearAsInt(); } catch (e) {}
print("Control does not reach here");
``` 
This bug was discovered by @ashwanidausodia 