### PR TITLE
math.pow for int32

### DIFF
--- a/plush/math.pls
+++ b/plush/math.pls
@@ -158,3 +158,48 @@ exports.ceil = function (x)
         "unhandled type in ceil function"
     );
 };
+
+
+exports.pow = function (base, exp) 
+{
+    // Anything to the power of zero is one.
+    if (exp == 0)
+    {
+        return 1;
+    }
+    
+    if (typeof base == "int32" && typeof exp == "int32")
+    {
+        var recip = false;
+        var result = 1;
+        if (exp < 0)
+        {
+            exp = -exp; // Make positive.
+            recip = true;
+        }
+        
+        for (;exp != 0;)
+        {
+            if ( (exp & 1) != 0)
+            {
+                result *= base;
+            }
+            exp >>= 1;
+            base *= base;
+        }
+           
+        if (recip)
+        {
+            return 1.0f / result;
+        }
+        else
+        {
+            return result;
+        }
+    }
+    
+    assert(
+        false,
+        "unhandled type in pow function"
+    );
+};

--- a/tests/plush/math.pls
+++ b/tests/plush/math.pls
@@ -86,3 +86,13 @@ assert (math.ceil(-3.3f) == -3);
 assert (math.ceil(-3.0f) == -3);
 
 assert (math.idiv(5, 2) == 2);
+
+assert(math.pow(4, 0) == 1);
+assert(math.pow(-4, 0) == 1);
+assert(math.pow(4, 1) == 4);
+assert(math.pow(-4, 1) == -4);
+assert(math.pow(4, 3) == 64);
+assert(math.pow(-4, 3) == -64);
+assert(math.pow(1, -1) == 1);
+assert(math.pow(2, -1) == 0.5f);
+assert(math.pow(-1, -3) == -1);


### PR DESCRIPTION
Supports negative exponents. Doesn't support floating point base or exponent.