### PR TITLE
String lpad and rpad functions

### DIFF
--- a/plush/string.pls
+++ b/plush/string.pls
@@ -480,6 +480,58 @@ exports.endsWith = function (string, needle)
 };
 
 /**
+ * Pads the beginning of a string with a character for a specified total length
+ */
+exports.lpad = function (string, paddingChar, totalWidth)
+{
+    if (paddingChar.length != 1)
+    {
+        throw "Can only have 1 padding character, you gave " + exports.toString(paddingChar.length);
+    }
+    
+    if (string.length >= totalWidth)
+    {
+        return string;
+    }
+    else
+    {
+        var toPad = totalWidth - string.length;
+        var padding = "";
+        for (;toPad > 0;toPad -= 1)
+        {
+            padding += paddingChar;
+        }
+        return padding + string;
+    }
+};
+
+/**
+ * Pads the end of a string with a character for a specified total length
+ */
+exports.rpad = function (string, paddingChar, totalWidth)
+{
+    if (paddingChar.length != 1)
+    {
+        throw "Can only have 1 padding character, you gave " + exports.toString(paddingChar.length);
+    }
+    
+    if (string.length >= totalWidth)
+    {
+        return string;
+    }
+    else
+    {
+        var toPad = totalWidth - string.length;
+        var padding = "";
+        for (;toPad > 0;toPad -= 1)
+        {
+            padding += paddingChar;
+        }
+        return string + padding;
+    }
+};
+
+/**
  * Prototype object containing functions usable as string methods
  * Note: useful for languages using prototypal inheritance
 */
@@ -498,6 +550,8 @@ exports.prototype = {
     toLower: exports.toLower,
     toUpper: exports.toUpper,
     format: exports.format,
+    lpad: exports.lpad,
+    rpad: exports.rpad,
 };
 
 //============================================================================

--- a/tests/plush/string.pls
+++ b/tests/plush/string.pls
@@ -137,6 +137,56 @@ assert(toUpper("ab cde") == "AB CDE");
 assert(toUpper("AB cde") == "AB CDE");
 assert(toUpper("AB CDE") == "AB CDE");
 
+//lpad
+var lpad = str.lpad;
+assert(lpad("Hello", " ", 7) == "  Hello");
+assert(lpad("Hello", ".", 7) == "..Hello");
+assert(lpad("Hello", " ", 3) == "Hello");
+assert(lpad("Hello", " ", -1) == "Hello");
+try 
+{
+    lpad("Hello", "", 7);
+    assert(false);
+}
+catch(e)
+{
+    assert(true);
+}
+try 
+{
+    lpad("Hello", "abcd", 7);
+    assert(false);
+}
+catch(e)
+{
+    assert(true);
+}
+
+//lpad
+var rpad = str.rpad;
+assert(rpad("Hello", " ", 7) == "Hello  ");
+assert(rpad("Hello", ".", 7) == "Hello..");
+assert(rpad("Hello", " ", 3) == "Hello");
+assert(rpad("Hello", " ", -1) == "Hello");
+try 
+{
+    rpad("Hello", "", 7);
+    assert(false);
+}
+catch(e)
+{
+    assert(true);
+}
+try 
+{
+    rpad("Hello", "abcd", 7);
+    assert(false);
+}
+catch(e)
+{
+    assert(true);
+}
+
 var startsWith = str.startsWith;
 assert(startsWith("Banana", "Ban"));
 assert(startsWith("Banana", ""));


### PR DESCRIPTION
The implementation of lpad and rpad doesn't truncate the strings if the desired width is less than the input strings width. Also only a single character can be used for padding currently.