### PR TITLE
Fix test running on Arch

### DIFF
--- a/espresso.sh
+++ b/espresso.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # Compile the input
-python espresso/main.py compile ${SRC_FILE} > ${PKG_FILE}
+python2 espresso/main.py compile ${SRC_FILE} > ${PKG_FILE}
 
 # Run the compiled output
 ./zeta ${PKG_FILE}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -119,7 +119,7 @@ set -x
 # espresso tests
 ##############################################################################
 
-python espresso/main.py test
+python2 espresso/main.py test
 ./espresso.sh tests/espresso/test.espr
 
 ##############################################################################


### PR DESCRIPTION
I attempted to run the tests on Arch Linux, and due to the default Python version here being python3, "zetavm/espresso/e_codegen.py", line 30, failed as "has_key" does not exist in python3 (just use "in").

This should also fix it for other platforms where Python3 is the default. Those where Python2 is not set will get a much easier error to deal with anyway.