### PR TITLE
Fix string length in optparser test code

### DIFF
--- a/vm/opt_parser.h
+++ b/vm/opt_parser.h
@@ -544,7 +544,7 @@ std::string OptParser::helpString()
 
 static char* testStrdup(const std::string &s)
 {
-    auto *temp = new char[s.length()];
+    auto *temp = new char[s.length() + 1];
     strcpy(temp, s.c_str());
     return temp;
 }


### PR DESCRIPTION
`s.length()` returns the length without the `\0` at the end.