### PR TITLE
Fix 3 problems on 32bit targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ matrix:
     - os: osx
     # works on Precise and Trusty
     - os: linux
-      env:
-         - CXX="g++" BUILD_ARCH="x86"
+      env: CXX="g++" BUILD_ARCH="x86"
     
     - os: linux
-      env:
-         - CXX="g++" BUILD_ARCH="x64"
+      env: CXX="g++" BUILD_ARCH="x64"
 
     # works on Precise and Trusty
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 
 script:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm ./configure ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make -j4 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make test ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make -j4 test ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make clean ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm "CXXFLAGS=-m32 make -j4 test"; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure && make -j4 && make test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       env:
          - CXX="clang++"
 
+
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x64" ]]; then docker build -t zetavm/testing -f Dockerfile . ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x86" ]]; then docker build -t zetavm/testing -f Dockerfile-32 . ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ matrix:
     # works on Precise and Trusty
     - os: linux
       env:
-         - CXX="g++"
+         - CXX="g++" BUILD_ARCH="x86"
+    
+    - os: linux
+      env:
+         - CXX="g++" BUILD_ARCH="x64"
 
     # works on Precise and Trusty
     - os: linux
@@ -24,12 +28,11 @@ matrix:
          - CXX="clang++"
 
 install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t zetavm/testing . ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x64"]]; then docker build -t zetavm/testing -f Dockefile . ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x86"]]; then docker build -t zetavm/testing -f Dockefile-32 . ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run -td --name zetavm -e CXX=$CXX zetavm/testing ; fi
 
 script:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm ./configure ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make -j4 test ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make clean ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm sh -c "CXXFLAGS=-m32 make -j4 test"; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure && make -j4 && make test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ script:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm ./configure ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make -j4 test ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm make clean ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm "CXXFLAGS=-m32 make -j4 test"; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec zetavm sh -c "CXXFLAGS=-m32 make -j4 test"; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure && make -j4 && make test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
          - CXX="clang++"
 
 install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x64"]]; then docker build -t zetavm/testing -f Dockefile . ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x86"]]; then docker build -t zetavm/testing -f Dockefile-32 . ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x64" ]]; then docker build -t zetavm/testing -f Dockerfile . ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD_ARCH" == "x86" ]]; then docker build -t zetavm/testing -f Dockerfile-32 . ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run -td --name zetavm -e CXX=$CXX zetavm/testing ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
 
     # works on Precise and Trusty
     - os: linux
-      env:
-         - CXX="clang++"
+      env: CXX="clang++" BUILD_ARCH="x64"
+
 
 
 install:

--- a/Dockerfile-32
+++ b/Dockerfile-32
@@ -9,3 +9,5 @@ RUN apt-get update && apt-get install -y \
     clang
 
 COPY ./ ./
+
+CMD sh

--- a/Dockerfile-32
+++ b/Dockerfile-32
@@ -1,0 +1,11 @@
+FROM pankona/xenial-32bit:latest
+
+MAINTAINER ZetaVM Developers
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    clang
+
+COPY ./ ./

--- a/makefile.in
+++ b/makefile.in
@@ -1,4 +1,4 @@
-CXXFLAGS=@CXXFLAGS@
+CXXFLAGS:= ${CXXFLAGS} @CXXFLAGS@
 LDFLAGS=@LDFLAGS@
 
 # TODO: change this when doing make install? Move to configure script?

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -519,7 +519,7 @@ void compile(BlockVersion* version)
             {
                 i += 1;
                 writeCode(GET_FIELD_IMM);
-                writeCode((refptr)val);
+                writeCode((Word)(refptr)val);
                 writeCode(size_t(0));
                 continue;
             }

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -519,7 +519,7 @@ void compile(BlockVersion* version)
             {
                 i += 1;
                 writeCode(GET_FIELD_IMM);
-                writeCode((Word)(refptr)val);
+                writeCode((refptr)val);
                 writeCode(size_t(0));
                 continue;
             }

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1112,8 +1112,8 @@ void compile(BlockVersion* version)
             // Push the import function on the stack
             numTmps += 1;
             writeCode(PUSH);
-            writeCode((refptr)&importFn);
-            writeCode(TAG_HOSTFN);
+            writeCode((Word)(refptr)&importFn);
+            writeCode((Tag)TAG_HOSTFN);
 
             // Call the import function
             genCall(

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -99,18 +99,18 @@ Value VM::alloc(uint32_t size, Tag tag)
 void Wrapper::setNextPtr(refptr obj, refptr nextPtr)
 {
     // Get the object header
-    auto header = *(uint64_t*)obj;
+    auto header = *(intptr_t*)obj;
 
     // Set the next pointer
     *(refptr*)(obj + OBJ_OF_NEXT) = nextPtr;
 
     // Set the next pointer flag bit in the object header
-    *(uint64_t*)(obj) = header | HEADER_MSK_NEXT;
+    *(intptr_t*)(obj) = header | HEADER_MSK_NEXT;
 }
 
 refptr Wrapper::getNextPtr(refptr obj, refptr notFound)
 {
-    auto header = *(uint64_t*)obj;
+    auto header = *(intptr_t*)obj;
     bool hasNextPtr = header & HEADER_MSK_NEXT;
 
     if (!hasNextPtr)

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -99,18 +99,18 @@ Value VM::alloc(uint32_t size, Tag tag)
 void Wrapper::setNextPtr(refptr obj, refptr nextPtr)
 {
     // Get the object header
-    auto header = *(intptr_t*)obj;
+    auto header = *(obj_header*)obj;
 
     // Set the next pointer
     *(refptr*)(obj + OBJ_OF_NEXT) = nextPtr;
 
     // Set the next pointer flag bit in the object header
-    *(intptr_t*)(obj) = header | HEADER_MSK_NEXT;
+    *(obj_header*)(obj) = header | HEADER_MSK_NEXT;
 }
 
 refptr Wrapper::getNextPtr(refptr obj, refptr notFound)
 {
-    auto header = *(intptr_t*)obj;
+    auto header = *(obj_header*)obj;
     bool hasNextPtr = header & HEADER_MSK_NEXT;
 
     if (!hasNextPtr)

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -12,6 +12,9 @@ typedef uint8_t Tag;
 /// Heap pointer type
 typedef uint8_t* refptr;
 
+/// Type of object header
+typedef uintptr_t obj_header;
+
 /// Type tag constants
 const Tag TAG_UNDEF     = 0;
 const Tag TAG_BOOL      = 1;
@@ -27,7 +30,7 @@ const Tag TAG_RAWPTR    = 10;
 const Tag TAG_IMGREF    = 11;
 
 /// Object header size
-const size_t HEADER_SIZE = sizeof(intptr_t);
+const size_t HEADER_SIZE = sizeof(obj_header);
 
 /// Bit flag indicating the next pointer is set
 const size_t HEADER_IDX_NEXT = 15;

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -41,7 +41,7 @@ const size_t OBJ_OF_NEXT = HEADER_SIZE;
 */
 union Word
 {
-    Word(refptr p) { ptr = p; }
+    Word(refptr p) { int64 = 0; ptr = p; }
     Word(int64_t v) { int64 = v; }
     Word(float v) { float32 = v; }
     Word() {}


### PR DESCRIPTION
There were assumptions that `sizeof(uint64_t) == sizeof(intptr_t) == sizeof(refptr)` in the code, which lead to the problems described in #116 .

Fixes #116 

`make test` now succeeds on my machine with `-m32` and without.